### PR TITLE
Implement mage image and spawn scaling

### DIFF
--- a/mage_roguelike_prototype.html
+++ b/mage_roguelike_prototype.html
@@ -46,6 +46,7 @@
     <p><strong>XP:</strong> <span id="xp">0</span></p>
     <p><strong>Upgrades:</strong> <span id="upgrades">None</span></p>
     <p><strong>Time:</strong> <span id="timer">0:00</span></p>
+    <button id="levelUpBtn">Level Up</button>
   </div>
   <div id="upgradePrompt">
     <p>Escolha onde aplicar o poder: <span id="upgradeElement"></span></p>
@@ -57,6 +58,8 @@
   <script>
     const canvas = document.getElementById("gameCanvas");
     const ctx = canvas.getContext("2d");
+    const mageImg = new Image();
+    mageImg.src = "mage.png";
 
     const state = {
       level: 1,
@@ -248,10 +251,14 @@
       ctx.fillStyle = "#444";
       ctx.fillRect(0, canvas.height - 30, canvas.width, 30);
 
-      ctx.fillStyle = "purple";
-      ctx.beginPath();
-      ctx.arc(player.x, player.y, player.radius, 0, Math.PI * 2);
-      ctx.fill();
+      if (mageImg.complete) {
+        ctx.drawImage(mageImg, player.x - 20, player.y - 20, 40, 40);
+      } else {
+        ctx.fillStyle = "purple";
+        ctx.beginPath();
+        ctx.arc(player.x, player.y, player.radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
 
       ctx.fillStyle = "green";
       state.enemies.forEach(e => ctx.fillRect(e.x, e.y, 30, 30));
@@ -292,7 +299,7 @@
       }
       if (Math.floor(state.timeFrames / 3600) > state.minutes) {
         state.minutes++;
-        state.spawnInterval = Math.max(10, Math.floor(state.spawnInterval * 0.85));
+        state.spawnInterval = Math.max(10, Math.floor(state.spawnInterval / 1.3));
       }
       if (state.paused) return;
 
@@ -377,6 +384,13 @@
       if (e.key.toLowerCase() === 'q') castQ();
       if (e.key.toLowerCase() === 'w') castW();
       if (e.key.toLowerCase() === 'e') castE();
+    });
+
+    document.getElementById('levelUpBtn').addEventListener('click', () => {
+      if (!state.pendingUpgrade) {
+        state.xp = state.xpToNext;
+        levelUp();
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace mage circle with `mage.png`
- add a Level Up button for quick testing
- spawn rate now rises 30% each minute

## Testing
- `pip install pillow` *(fails: not needed for runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad7f1e2083339622880aa2ef0b01