### PR TITLE
Add enemy types and spawn scaling

### DIFF
--- a/mage_roguelike_prototype.html
+++ b/mage_roguelike_prototype.html
@@ -84,8 +84,8 @@
       mouseY: 0,
       spawnInterval: 60,
       spawnTimer: 60,
+      spawnIncreaseTimer: 1800,
       timeFrames: 0,
-      minutes: 0,
       beams: []
     };
 
@@ -97,17 +97,29 @@
     };
 
     function spawnEnemy() {
-      const flying = Math.random() < 0.2;
-      const spd = 1 + Math.random();
+      const r = Math.random();
+      let type = 'miniom';
+      if (r > 0.6 && r <= 0.8) type = 'tanker';
+      else if (r > 0.8) type = 'voador';
+
+      const baseStats = {
+        miniom: { hp: 3, speed: 1.5, size: 30 },
+        tanker: { hp: 8, speed: 0.8, size: 45 },
+        voador: { hp: 2, speed: 2.2, size: 25 }
+      };
+      const mult = Math.pow(1.5, Math.floor(state.level / 5));
+      const stats = baseStats[type];
       state.enemies.push({
         x: canvas.width + 20,
-        y: flying ? canvas.height / 2 : canvas.height - 60,
-        speed: spd,
-        hp: 3,
+        y: type === 'voador' ? canvas.height / 2 : canvas.height - stats.size - 30,
+        speed: stats.speed,
+        hp: Math.floor(stats.hp * mult),
+        size: stats.size,
         burn: 0,
         slow: 0,
         knockback: 0,
-        flying
+        type,
+        flying: type === 'voador'
       });
     }
 
@@ -269,8 +281,12 @@
         ctx.fill();
       }
 
-      ctx.fillStyle = "green";
-      state.enemies.forEach(e => ctx.fillRect(e.x, e.y, 30, 30));
+      state.enemies.forEach(e => {
+        if (e.type === 'tanker') ctx.fillStyle = 'brown';
+        else if (e.type === 'voador') ctx.fillStyle = 'yellow';
+        else ctx.fillStyle = 'green';
+        ctx.fillRect(e.x, e.y, e.size, e.size);
+      });
 
       state.bullets.forEach(b => {
         ctx.fillStyle = b.color || "white";
@@ -306,9 +322,9 @@
         spawnEnemy();
         state.spawnTimer = state.spawnInterval;
       }
-      if (Math.floor(state.timeFrames / 3600) > state.minutes) {
-        state.minutes++;
-        state.spawnInterval = Math.max(10, Math.floor(state.spawnInterval / 1.3));
+      if (--state.spawnIncreaseTimer <= 0) {
+        state.spawnInterval = Math.max(5, Math.floor(state.spawnInterval * 2 / 3));
+        state.spawnIncreaseTimer = 1800;
       }
       if (state.paused) return;
 
@@ -325,7 +341,7 @@
 
         const spd = e.slow > 0 ? e.speed * 0.5 : e.speed;
         e.x -= spd;
-        if (e.hp > 0 && e.x > -40) remainingEnemies.push(e);
+        if (e.hp > 0 && e.x > -e.size) remainingEnemies.push(e);
         else if (e.hp <= 0) state.xp++;
       });
       state.enemies = remainingEnemies;
@@ -360,7 +376,8 @@
         b.y += b.dy;
         for (let i = 0; i < state.enemies.length; i++) {
           const e = state.enemies[i];
-          if (Math.abs(b.x - e.x) < 20 && Math.abs(b.y - e.y) < 20) {
+          const half = e.size / 2;
+          if (Math.abs(b.x - (e.x + half)) < half && Math.abs(b.y - (e.y + half)) < half) {
             applyElementEffects(e, b.elements);
             e.hp -= b.dmg;
             if (e.hp <= 0) {
@@ -376,7 +393,7 @@
       // simple barrier collision
       state.barriers = state.barriers.filter(barr => {
         state.enemies.forEach(e => {
-          if (e.x < barr.x + barr.width && e.x + 30 > barr.x && e.y < barr.y + barr.height && e.y + 30 > barr.y) {
+          if (e.x < barr.x + barr.width && e.x + e.size > barr.x && e.y < barr.y + barr.height && e.y + e.size > barr.y) {
             applyElementEffects(e, barr.elements);
             e.x = barr.x + barr.width;
             barr.hp--;


### PR DESCRIPTION
## Summary
- add new enemy types (miniom, tanker, voador)
- scale enemy HP every 5 levels
- increase spawn rate by 50% every 30 seconds
- support different enemy sizes and colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849b3cb9a188333b20e7704a3596032