### PR TITLE
Fix combo display in ability HUD

### DIFF
--- a/mage_roguelike_prototype.html
+++ b/mage_roguelike_prototype.html
@@ -308,13 +308,19 @@
       return m + ":" + (s < 10 ? "0" + s : s);
     }
 
+    function formatElements(elems) {
+      if (!elems || elems.length === 0) return '-';
+      const combo = getComboName(elems);
+      return combo || elems.join(',');
+    }
+
     function updateHUD() {
       document.getElementById("level").textContent = state.level;
       const pct = Math.min(1, state.xp / state.xpToNext) * 100;
       document.getElementById("xpBar").style.width = pct + "%";
-      document.getElementById("qUpgrades").textContent = state.upgrades.Q.join(",") || "-";
-      document.getElementById("wUpgrades").textContent = state.upgrades.W.join(",") || "-";
-      document.getElementById("eUpgrades").textContent = state.upgrades.E.join(",") || "-";
+      document.getElementById("qUpgrades").textContent = formatElements(state.upgrades.Q);
+      document.getElementById("wUpgrades").textContent = formatElements(state.upgrades.W);
+      document.getElementById("eUpgrades").textContent = formatElements(state.upgrades.E);
       document.getElementById("timer").textContent = formatTime(state.timeFrames);
       document.getElementById("comboName").textContent = state.comboTimer > 0 ? state.comboName : "None";
     }


### PR DESCRIPTION
## Summary
- show combo names in Q, W and E HUD slots if available

## Testing
- `node -e 'const comboMap={"Fire,Ice":"Vapor","Fire,Fire":"Chama Azul"};function getComboName(e){if(!e||e.length<2)return null;const key=e.slice(0,3).sort().join(",");return comboMap[key]||null;}function formatElements(a){if(!a||a.length===0)return "-";const combo=getComboName(a);return combo||a.join(",");} console.log(formatElements(["Fire"])); console.log(formatElements(["Fire","Fire"])); console.log(formatElements([]));'`

------
https://chatgpt.com/codex/tasks/task_e_6849b96a8f348333aa6402d6cb29381b