### PR TITLE
Adjust elemental upgrade effects

### DIFF
--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -24,12 +24,16 @@ experiência e sobe de nível, você pode melhorar atributos gerais ou adicionar
 Quando um feitiço possui um elemento, o efeito é aplicado toda vez que atinge um
 inimigo:
 
-- **Fire**: aplica queimadura por 60 quadros. A cada 20 quadros o inimigo sofre
-  1 de dano extra.
-- **Ice**: deixa o inimigo lento por 60 quadros, reduzindo sua velocidade pela
-  metade.
-- **Wind**: empurra o inimigo 20 pixels para a direita (para longe do jogador).
-  Se o inimigo estiver rápido, o recuo pode parecer pequeno.
+- **Fire**: causa dano ao longo do tempo. Com um upgrade, provoca `0,5` de dano
+  por segundo durante `3` segundos. Com dois upgrades, o dano passa para `1` por
+  segundo durante `3` segundos. Com três upgrades, o inimigo sofre `2` de dano
+  por segundo por `5` segundos. O efeito não acumula e os oponentes queimando
+  piscam na tela.
+- **Ice**: reduz a velocidade do alvo. Um upgrade diminui em `25%` por `1,5`
+  segundo; dois upgrades diminuem em `50%` por `2` segundos; três upgrades
+  imobilizam o alvo por `2` segundos.
+- **Wind**: empurra o inimigo para trás. Com um upgrade o recuo é de `20` pixels;
+  com dois, `40` pixels; com três, `80` pixels.
 
 ## Feitiços
 
@@ -55,10 +59,9 @@ inimigo:
 
 ## Observação sobre o elemento Vento
 
-O código empurra o inimigo 20 pixels para a direita sempre que o elemento
-Vento é aplicado. Como os inimigos se movem constantemente para a esquerda,
-esse recuo pode ser discreto. Para um efeito mais visível, seria preciso
-ajustar esse valor ou aplicar a força de forma repetida.
+O recuo provocado por **Vento** varia conforme a quantidade de upgrades
+adquiridos. Inimigos podem ser arremessados para longe (20, 40 ou 80 pixels),
+o que torna o efeito perceptível mesmo contra adversários rápidos.
 
 ## Combinações Elementais
 

--- a/mage_roguelike_prototype.html
+++ b/mage_roguelike_prototype.html
@@ -172,7 +172,9 @@
         hp: Math.floor(stats.hp * mult),
         size: stats.size,
         burn: 0,
+        burnDamage: 0,
         slow: 0,
+        slowFactor: 1,
         knockback: 0,
         type,
         flying: type === 'voador'
@@ -381,6 +383,10 @@
           else ctx.fillStyle = 'green';
           ctx.fillRect(e.x, e.y, e.size, e.size);
         }
+        if (e.burn > 0 && state.timeFrames % 20 < 10) {
+          ctx.fillStyle = 'rgba(255,100,0,0.5)';
+          ctx.fillRect(e.x, e.y, e.size, e.size);
+        }
       });
 
       state.bullets.forEach(b => {
@@ -410,9 +416,24 @@
         state.comboName = combo;
         state.comboTimer = 120;
       }
-      if (elements.includes('Fire')) enemy.burn = 60;
-      if (elements.includes('Ice')) enemy.slow = 60;
-      if (elements.includes('Wind')) enemy.knockback = 20;
+
+      const fireCount = elements.filter(e => e === 'Fire').length;
+      const iceCount = elements.filter(e => e === 'Ice').length;
+      const windCount = elements.filter(e => e === 'Wind').length;
+
+      if (fireCount > 0) {
+        enemy.burn = fireCount >= 3 ? 300 : 180; // frames
+        enemy.burnDamage = fireCount === 1 ? 0.5 : fireCount === 2 ? 1 : 2;
+      }
+
+      if (iceCount > 0) {
+        enemy.slow = iceCount >= 3 ? 120 : iceCount === 2 ? 120 : 90;
+        enemy.slowFactor = iceCount >= 3 ? 0 : iceCount === 2 ? 0.5 : 0.75;
+      }
+
+      if (windCount > 0) {
+        enemy.knockback = windCount === 1 ? 20 : windCount === 2 ? 40 : 80;
+      }
     }
 
     function updateGame() {
@@ -431,8 +452,14 @@
 
       const remainingEnemies = [];
       state.enemies.forEach(e => {
-        if (e.burn > 0 && --e.burn % 20 === 0) e.hp--;
-        if (e.slow > 0) e.slow--;
+        if (e.burn > 0) {
+          e.burn--;
+          e.hp -= e.burnDamage / 60;
+        }
+        if (e.slow > 0) {
+          e.slow--;
+          if (e.slow === 0) e.slowFactor = 1;
+        }
 
         if (e.knockback && e.knockback > 0) {
           e.x += e.knockback;
@@ -440,7 +467,7 @@
           if (e.knockback < 1) e.knockback = 0;
         }
 
-        const spd = e.slow > 0 ? e.speed * 0.5 : e.speed;
+        const spd = e.slow > 0 ? e.speed * e.slowFactor : e.speed;
         e.x -= spd;
         if (e.hp > 0 && e.x > -e.size) remainingEnemies.push(e);
         else if (e.hp <= 0) state.xp++;


### PR DESCRIPTION
## Summary
- tweak elemental upgrade descriptions
- implement per-level effects for Fire, Ice and Wind
- show burning enemies blinking red

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849bd73a9a083339189bccca946734e