### PR TITLE
Add constants for spawn scaling and XP handling

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,8 @@
 const GAME_CONSTANTS = {
   SPAWN_INTERVAL: 110, // time between enemy spawns in frames
-  SPAWN_INCREASE_TIMER: 1200, // frames until spawn interval increases
+  SPAWN_INCREASE_SECONDS: 20, // seconds until spawn interval increases
+  SPAWN_INCREASE_TIMER: 20 * 60, // frames until spawn interval increases
+  SPAWN_INCREASE_COEFF: 1.2, // multiplier applied to spawnInterval
   PLAYER_SPEED: 3, // player movement speed
   PLAYER_MAX_HP: 10, // base player life (unused yet)
   BULLET_SPEED: 5, // speed of basic player bullets
@@ -13,6 +15,8 @@ const GAME_CONSTANTS = {
   TANKER_DASH_COOLDOWN_VAR: 240, // additional random cooldown range
   TANKER_DASH_DURATION: 70, // duration of tanker dash
   DASH_SPEED_MULTIPLIER: 3, // speed multiplier while dashing
+  XP_PER_ENEMY: 1, // experience points gained per enemy defeated
+  XP_LEVEL_COEFF: 1.3, // multiplier for XP needed per level
   ENEMY_BASE_STATS: {
     miniom: { hp: 3, speed: 1.8, size: 60 },
     tanker: { hp: 10, speed: 1, size: 100 },

--- a/script.js
+++ b/script.js
@@ -254,7 +254,9 @@ function getComboName(elems) {
 function levelUp() {
   state.xp -= state.xpToNext;
   state.level++;
-  state.xpToNext = Math.floor(state.xpToNext * 1.3);
+  state.xpToNext = Math.floor(
+    state.xpToNext * GAME_CONSTANTS.XP_LEVEL_COEFF
+  );
 
   const opts = [];
   while (opts.length < 3) {
@@ -478,7 +480,9 @@ function updateGame() {
     state.spawnTimer = state.spawnInterval;
   }
   if (--state.spawnIncreaseTimer <= 0) {
-    state.spawnInterval = Math.floor(state.spawnInterval * 1.2);
+    state.spawnInterval = Math.floor(
+      state.spawnInterval * GAME_CONSTANTS.SPAWN_INCREASE_COEFF
+    );
     state.spawnIncreaseTimer = GAME_CONSTANTS.SPAWN_INCREASE_TIMER;
   }
   if (state.paused) return;
@@ -538,8 +542,11 @@ function updateGame() {
       }
     }
     e.x -= spd;
-    if (e.hp > 0 && e.x > -e.size) remainingEnemies.push(e);
-    else if (e.hp <= 0) state.xp++;
+    if (e.hp > 0 && e.x > -e.size) {
+      remainingEnemies.push(e);
+    } else if (e.hp <= 0) {
+      state.xp += GAME_CONSTANTS.XP_PER_ENEMY;
+    }
   });
   state.enemies = remainingEnemies;
 
@@ -594,7 +601,7 @@ function updateGame() {
         }
         if (e.hp <= 0) {
           state.enemies.splice(i, 1);
-          state.xp++;
+          state.xp += GAME_CONSTANTS.XP_PER_ENEMY;
         }
         return false;
       }


### PR DESCRIPTION
## Summary
- define constants for spawn scaling coefficient and timing
- add XP per enemy and XP level multiplier constants
- use the new constants in game logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849cecdb3208333b4c37084362eeaad