### PR TITLE
Define constant for fast shot upgrade

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -25,3 +25,11 @@ const GAME_CONSTANTS = {
     voador: { hp: 2, speed: 2.5, size: 50 },
   },
 };
+
+// upgrade definitions
+const UPGRADE_FAST_SHOT = {
+  type: "stat",
+  prop: "autoFireDelay",
+  value: -5,
+  desc: "Tiros mais rápidos",
+};

--- a/script.js
+++ b/script.js
@@ -195,12 +195,7 @@ function getBulletColor(elements) {
 
 const elementOptions = ["Fire", "Ice", "Wind"];
 const generalUpgradesPool = [
-  {
-    type: "stat",
-    prop: "autoFireDelay",
-    value: -5,
-    desc: "Tiros mais rápidos",
-  },
+  UPGRADE_FAST_SHOT,
   { type: "stat", prop: "baseDamage", value: 1, desc: "+1 dano base" },
   { type: "stat", prop: "qDamageBonus", value: 1, desc: "+1 dano do Q" },
   { type: "stat", prop: "wBonusHp", value: 5, desc: "+5 vida do W" },


### PR DESCRIPTION
## Summary
- add a constant object to hold the "faster shot" upgrade
- reuse the constant inside `generalUpgradesPool`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849d378501c83339511198a9fd8c8af