### PR TITLE
Add more upgrade constants

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -33,3 +33,59 @@ const UPGRADE_FAST_SHOT = {
   value: -10,
   desc: "Tiros mais rápidos",
 };
+
+const UPGRADE_BASE_DAMAGE = {
+  type: "stat",
+  prop: "baseDamage",
+  value: 1,
+  desc: "+1 dano base",
+};
+
+const UPGRADE_Q_DAMAGE = {
+  type: "stat",
+  prop: "qDamageBonus",
+  value: 1,
+  desc: "+1 dano do Q",
+};
+
+const UPGRADE_W_HEALTH = {
+  type: "stat",
+  prop: "wBonusHp",
+  value: 5,
+  desc: "+5 vida do W",
+};
+
+const UPGRADE_E_DAMAGE = {
+  type: "stat",
+  prop: "eDamageBonus",
+  value: 1,
+  desc: "+1 dano do E",
+};
+
+const UPGRADE_Q_COOLDOWN = {
+  type: "stat",
+  prop: "qCooldown",
+  value: -30,
+  desc: "Q recarrega mais rápido",
+};
+
+const UPGRADE_TURRET_FASTER = {
+  type: "stat",
+  prop: "turretFireDelay",
+  value: -10,
+  desc: "Torreta atira mais rápido",
+};
+
+const UPGRADE_BARRIER_HEIGHT = {
+  type: "stat",
+  prop: "barrierHeight",
+  value: 10,
+  desc: "Barreira mais alta",
+};
+
+const UPGRADE_BULLET_AOE = {
+  type: "stat",
+  prop: "bulletAOE",
+  value: 20,
+  desc: "Ataque básico em área",
+};

--- a/script.js
+++ b/script.js
@@ -196,29 +196,14 @@ function getBulletColor(elements) {
 const elementOptions = ["Fire", "Ice", "Wind"];
 const generalUpgradesPool = [
   UPGRADE_FAST_SHOT,
-  { type: "stat", prop: "baseDamage", value: 1, desc: "+1 dano base" },
-  { type: "stat", prop: "qDamageBonus", value: 1, desc: "+1 dano do Q" },
-  { type: "stat", prop: "wBonusHp", value: 5, desc: "+5 vida do W" },
-  { type: "stat", prop: "eDamageBonus", value: 1, desc: "+1 dano do E" },
-  {
-    type: "stat",
-    prop: "qCooldown",
-    value: -30,
-    desc: "Q recarrega mais rápido",
-  },
-  {
-    type: "stat",
-    prop: "turretFireDelay",
-    value: -10,
-    desc: "Torreta atira mais rápido",
-  },
-  {
-    type: "stat",
-    prop: "barrierHeight",
-    value: 10,
-    desc: "Barreira mais alta",
-  },
-  { type: "stat", prop: "bulletAOE", value: 20, desc: "Ataque básico em área" },
+  UPGRADE_BASE_DAMAGE,
+  UPGRADE_Q_DAMAGE,
+  UPGRADE_W_HEALTH,
+  UPGRADE_E_DAMAGE,
+  UPGRADE_Q_COOLDOWN,
+  UPGRADE_TURRET_FASTER,
+  UPGRADE_BARRIER_HEIGHT,
+  UPGRADE_BULLET_AOE,
 ];
 
 const comboMap = {


### PR DESCRIPTION
## Summary
- add extra upgrade objects to constants.js
- reference the new constants inside the upgrades pool

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4b990ec83339e0d16127aa8a0df