### PR TITLE
Fix elemental effects application for Q spell

### DIFF
--- a/script.js
+++ b/script.js
@@ -132,7 +132,9 @@ function castQ() {
   const range = 15 + state.upgrades.Q.length * 10;
   state.cooldowns.Q = state.qCooldown;
   state.enemies.forEach((e) => {
-    if (e.y > player.y - range && e.y < player.y + range && e.x > player.x) {
+    // calcula usando o centro do inimigo para acertar o Q em alvos grandes
+    const centerY = e.y + e.size / 2;
+    if (centerY > player.y - range && centerY < player.y + range && e.x > player.x) {
       // usamos uma cópia para evitar mudar o array de elementos da magia
       applyElementEffects(e, state.spellElements.Q.slice());
       e.hp -= state.baseDamage + state.qDamageBonus;


### PR DESCRIPTION
## Summary
- adjust Q spell collision to use enemy center when determining hits
  - this ensures large enemies are properly affected by Fire, Ice and Wind upgrades

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849de51dfb0833380334dca6cf69144