### PR TITLE
Implement enemy clear on level up with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/levelUp.test.js
+++ b/__tests__/levelUp.test.js
@@ -1,0 +1,30 @@
+const { JSDOM } = require('jsdom');
+const constants = require('../constants.js');
+
+beforeEach(() => {
+  // create DOM
+  const dom = new JSDOM(`<!DOCTYPE html><canvas id="gameCanvas"></canvas><div id="generalUpgradePrompt"></div><div id="upgradePrompt"></div><span id="upgradeElement"></span><div id="level"></div><div id="xpBar"></div><div id="qUpgrades"></div><div id="wUpgrades"></div><div id="eUpgrades"></div><div id="timer"></div><div id="comboName"></div><button id="levelUpBtn"></button>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.Image = dom.window.Image;
+  global.GAME_CONSTANTS = constants.GAME_CONSTANTS;
+  global.UPGRADE_FAST_SHOT = constants.UPGRADE_FAST_SHOT;
+  global.UPGRADE_BASE_DAMAGE = constants.UPGRADE_BASE_DAMAGE;
+  global.UPGRADE_Q_DAMAGE = constants.UPGRADE_Q_DAMAGE;
+  global.UPGRADE_W_HEALTH = constants.UPGRADE_W_HEALTH;
+  global.UPGRADE_E_DAMAGE = constants.UPGRADE_E_DAMAGE;
+  global.UPGRADE_Q_COOLDOWN = constants.UPGRADE_Q_COOLDOWN;
+  global.UPGRADE_TURRET_FASTER = constants.UPGRADE_TURRET_FASTER;
+  global.UPGRADE_BARRIER_HEIGHT = constants.UPGRADE_BARRIER_HEIGHT;
+  global.UPGRADE_BULLET_AOE = constants.UPGRADE_BULLET_AOE;
+  const canvas = document.getElementById('gameCanvas');
+  canvas.getContext = () => ({ clearRect() {}, fillRect() {}, beginPath() {}, arc() {}, fill() {}, drawImage() {}, stroke() {}, lineTo() {}, moveTo() {} });
+});
+
+test('level up clears all enemies', () => {
+  const { state, levelUp } = require('../script.js');
+  state.enemies = [ { hp: 5 }, { hp: 3 } ];
+  state.xp = state.xpToNext;
+  levelUp();
+  expect(state.enemies.length).toBe(0);
+});

--- a/constants.js
+++ b/constants.js
@@ -91,3 +91,18 @@ const UPGRADE_BULLET_AOE = {
   value: 40,
   desc: "Ataque básico em área",
 };
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    GAME_CONSTANTS,
+    UPGRADE_FAST_SHOT,
+    UPGRADE_BASE_DAMAGE,
+    UPGRADE_Q_DAMAGE,
+    UPGRADE_W_HEALTH,
+    UPGRADE_E_DAMAGE,
+    UPGRADE_Q_COOLDOWN,
+    UPGRADE_TURRET_FASTER,
+    UPGRADE_BARRIER_HEIGHT,
+    UPGRADE_BULLET_AOE,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "rougue-like-concept",
+  "version": "1.0.0",
+  "description": "",
+  "main": "constants.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.0",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -240,6 +240,12 @@ function levelUp() {
     state.xpToNext * GAME_CONSTANTS.XP_LEVEL_COEFF
   );
 
+  // derrotar automaticamente todos inimigos em campo
+  state.enemies.forEach((e) => {
+    e.hp = 0;
+  });
+  state.enemies = [];
+
   const opts = [];
   while (opts.length < 3) {
     const rand =
@@ -622,23 +628,29 @@ function gameLoop() {
   requestAnimationFrame(gameLoop);
 }
 
-gameLoop();
+if (typeof module === "undefined") {
+  gameLoop();
 
-canvas.addEventListener("mousemove", (e) => {
-  const rect = canvas.getBoundingClientRect();
-  state.mouseX = e.clientX - rect.left;
-  state.mouseY = e.clientY - rect.top;
-});
+  canvas.addEventListener("mousemove", (e) => {
+    const rect = canvas.getBoundingClientRect();
+    state.mouseX = e.clientX - rect.left;
+    state.mouseY = e.clientY - rect.top;
+  });
 
-document.addEventListener("keydown", (e) => {
-  if (e.key.toLowerCase() === "q") castQ();
-  if (e.key.toLowerCase() === "w") castW();
-  if (e.key.toLowerCase() === "e") castE();
-});
+  document.addEventListener("keydown", (e) => {
+    if (e.key.toLowerCase() === "q") castQ();
+    if (e.key.toLowerCase() === "w") castW();
+    if (e.key.toLowerCase() === "e") castE();
+  });
 
-document.getElementById("levelUpBtn").addEventListener("click", () => {
-  if (!state.pendingUpgrade) {
-    state.xp = state.xpToNext;
-    levelUp();
-  }
-});
+  document.getElementById("levelUpBtn").addEventListener("click", () => {
+    if (!state.pendingUpgrade) {
+      state.xp = state.xpToNext;
+      levelUp();
+    }
+  });
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { state, levelUp };
+}


### PR DESCRIPTION
## Summary
- add Node.js test infrastructure with Jest
- export constants for tests and support CommonJS
- when leveling up, clear all enemies automatically
- make browser-specific code conditional for Node usage
- test that leveling up clears enemies
- ignore node modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e1305f3883339693ba2f67151010