### PR TITLE
Add Troll enemy with log barrier

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -25,6 +25,7 @@ const GAME_CONSTANTS = {
     miniom: { hp: 2, speed: 1.8, size: 60 },
     tanker: { hp: 8, speed: 1, size: 100 },
     voador: { hp: 1, speed: 2.5, size: 50 },
+    troll: { hp: 30, speed: 0.7, size: 120 },
   },
 };
 

--- a/mage_roguelike_prototype.html
+++ b/mage_roguelike_prototype.html
@@ -20,6 +20,7 @@
     <p><strong>Time:</strong> <span id="timer">0:00</span></p>
     <p><strong>Combo:</strong> <span id="comboName">None</span></p>
     <button id="levelUpBtn">Level Up</button>
+    <button id="spawnTrollBtn">Spawn Troll</button>
   </div>
   <div id="upgradePrompt">
     <p>Escolha onde aplicar o poder: <span id="upgradeElement"></span></p>


### PR DESCRIPTION
## Summary
- create troll assets for gameplay
- allow spawnEnemy to accept a specific type
- add troll stats in constants
- spawn log barrier when troll dies
- draw images for trolls and logs
- add button to spawn trolls for testing

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684a1ce6c33883339619afebf0753fb3