### PR TITLE
Reduce bat and troll spawn rate

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -27,6 +27,12 @@ const GAME_CONSTANTS = {
     voador: { hp: 1, speed: 2.5, size: 50 },
     troll: { hp: 30, speed: 0.7, size: 120 },
   },
+  ENEMY_SPAWN_WEIGHTS: {
+    miniom: 60,
+    tanker: 25,
+    voador: 10,
+    troll: 5,
+  },
 };
 
 // upgrade definitions

--- a/script.js
+++ b/script.js
@@ -71,12 +71,24 @@ const player = {
 };
 
 function spawnEnemy(forcedType) {
-  const r = Math.random();
   let type = forcedType || "miniom";
   if (!forcedType) {
-    if (r > 0.9 && state.timeFrames >= 14400) type = "troll";
-    else if (r > 0.8 && state.timeFrames >= 7200) type = "voador";
-    else if (r > 0.6 && state.timeFrames >= 3600) type = "tanker";
+    const weights = GAME_CONSTANTS.ENEMY_SPAWN_WEIGHTS;
+    const entries = [
+      ["miniom", weights.miniom, 0],
+      ["tanker", weights.tanker, 3600],
+      ["voador", weights.voador, 7200],
+      ["troll", weights.troll, 14400],
+    ].filter(([t, _w, frame]) => state.timeFrames >= frame);
+    const totalWeight = entries.reduce((sum, [, w]) => sum + w, 0);
+    let r = Math.random() * totalWeight;
+    for (const [t, w] of entries) {
+      if (r < w) {
+        type = t;
+        break;
+      }
+      r -= w;
+    }
   }
 
   const baseStats = GAME_CONSTANTS.ENEMY_BASE_STATS;


### PR DESCRIPTION
## Summary
- introduce `ENEMY_SPAWN_WEIGHTS` to control probabilities
- spawn enemies using weighted randomness so bats and trolls appear less often

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a22f267f4833388b7d3543a23d62a