### PR TITLE
Increase troll enemy size

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -26,7 +26,7 @@ const GAME_CONSTANTS = {
     miniom: { hp: 2, speed: 1.8, size: 60 },
     tanker: { hp: 8, speed: 1, size: 100 },
     voador: { hp: 1, speed: 2.5, size: 50 },
-    troll: { hp: 30, speed: 0.7, size: 120 },
+    troll: { hp: 30, speed: 0.7, size: 240 },
   },
   ENEMY_SPAWN_WEIGHTS: {
     miniom: 60,


### PR DESCRIPTION
## Summary
- double the troll's `size` attribute to make the troll larger

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a2b198ca083338b5782191a39a3a1