### PR TITLE
Add orc walking animation

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -20,6 +20,7 @@ const GAME_CONSTANTS = {
   TANKER_DASH_DURATION: 70, // duração da investida do tanker
   DASH_SPEED_MULTIPLIER: 3, // multiplicador de velocidade na investida
   TRUNK_BASE_Y: 150, // altura do topo do tronco em relação à base da tela
+  ORC_ANIMATION_SPEED: 10, // quadros entre quadros da animação do orc
   XP_PER_ENEMY: 3, // XP ganho por inimigo derrotado
   XP_LEVEL_COEFF: 1.2, // multiplicador do XP necessário por nível
   ENEMY_BASE_STATS: {

--- a/script.js
+++ b/script.js
@@ -13,8 +13,10 @@ const mageImg = new Image();
 mageImg.src = "mage.png";
 const goblinImg = new Image();
 goblinImg.src = "goblin.png";
-const orcImg = new Image();
-orcImg.src = "orc.png";
+const orcFrames = [new Image(), new Image(), new Image()];
+orcFrames[0].src = "orc-1.png";
+orcFrames[1].src = "orc-2.png";
+orcFrames[2].src = "orc-3.png";
 const batImg = new Image();
 batImg.src = "bat.png";
 const magiaImg = new Image();
@@ -58,6 +60,7 @@ const state = {
   spawnTimer: GAME_CONSTANTS.SPAWN_INTERVAL,
   spawnIncreaseTimer: GAME_CONSTANTS.SPAWN_INCREASE_TIMER,
   timeFrames: 0,
+  orcFrame: 0,
   beams: [],
   comboName: "",
   comboTimer: 0,
@@ -429,7 +432,7 @@ function drawGame() {
 
   state.enemies.forEach((e) => {
     let img;
-    if (e.type === "tanker") img = orcImg;
+    if (e.type === "tanker") img = orcFrames[state.orcFrame];
     else if (e.type === "voador") img = batImg;
     else if (e.type === "troll") img = trollImg;
     else img = goblinImg;
@@ -513,6 +516,9 @@ function applyElementEffects(enemy, elements) {
 
 function updateGame() {
   state.timeFrames++;
+  if (state.timeFrames % GAME_CONSTANTS.ORC_ANIMATION_SPEED === 0) {
+    state.orcFrame = (state.orcFrame + 1) % orcFrames.length;
+  }
   if (state.comboTimer > 0) state.comboTimer--;
   if (++state.autoFireTimer % state.autoFireDelay === 0) shootBasic();
   if (!state.paused) {


### PR DESCRIPTION
## Summary
- animate the orc enemy using a 3-frame cycle of `orc-1.png`, `orc-2.png`, and `orc-3.png`
- expose new `ORC_ANIMATION_SPEED` constant

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac5ace1248333a70f77e7c55b5562