### PR TITLE
Add enemy hp bars and cooldown display

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -24,6 +24,8 @@ const GAME_CONSTANTS = {
   GOBLIN_ANIMATION_SPEED: 10, // quadros entre quadros da animação do goblin
   XP_PER_ENEMY: 3, // XP ganho por inimigo derrotado
   XP_LEVEL_COEFF: 1.2, // multiplicador do XP necessário por nível
+  ENEMY_HP_LEVEL_COEFF: 1.05, // multiplicador de HP por nível
+  ENEMY_SPEED_LEVEL_COEFF: 1.01, // multiplicador de velocidade por nível
   ENEMY_BASE_STATS: {
     miniom: { hp: 2, speed: 1.8, size: 60 },
     tanker: { hp: 8, speed: 1, size: 100 },

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
 <body>
   <div id="xpBarContainer"><div id="xpBar"></div></div>
   <div id="abilityBar">
-    <div class="ability"><span class="key">Q</span><span id="qUpgrades">-</span></div>
-    <div class="ability"><span class="key">W</span><span id="wUpgrades">-</span></div>
-    <div class="ability"><span class="key">E</span><span id="eUpgrades">-</span></div>
+    <div class="ability"><span class="key">Q</span><span id="qUpgrades">-</span><span class="cd" id="qCd"></span></div>
+    <div class="ability"><span class="key">W</span><span id="wUpgrades">-</span><span class="cd" id="wCd"></span></div>
+    <div class="ability"><span class="key">E</span><span id="eUpgrades">-</span><span class="cd" id="eCd"></span></div>
   </div>
   <div id="hud">
     <p><strong>Level:</strong> <span id="level">1</span></p>

--- a/style.css
+++ b/style.css
@@ -74,6 +74,10 @@
       font-weight: bold;
       margin-right: 4px;
     }
+    .ability .cd {
+      margin-left: 4px;
+      color: #ffb;
+    }
 
     .overlay {
       position: absolute;


### PR DESCRIPTION
## Summary
- show ability cooldowns beside Q, W and E keys
- draw health bars and damage flash on enemies
- scale enemy stats per level via constants

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b208940888333b118daefa2a00ac1