### PR TITLE
Add mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,14 @@
   </div>
   <div id="generalUpgradePrompt"></div>
   <canvas id="gameCanvas" width="960" height="540"></canvas>
+  <div id="mobileControls">
+    <div id="shootPad"></div>
+    <div id="skillButtons">
+      <button id="btnQ">Q</button>
+      <button id="btnW">W</button>
+      <button id="btnE">E</button>
+    </div>
+  </div>
   <script src="constants.js"></script>
   <script src="script.js"></script>
 

--- a/script.js
+++ b/script.js
@@ -3,6 +3,9 @@ const ctx = canvas.getContext("2d");
 const overlay = document.getElementById("overlay");
 const menuOverlay = document.getElementById("menuOverlay");
 const resumeBtn = document.getElementById("resumeBtn");
+const isMobile =
+  typeof navigator !== "undefined" &&
+  ("ontouchstart" in window || navigator.maxTouchPoints > 0);
 function resizeCanvas() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
@@ -772,6 +775,32 @@ if (typeof module === "undefined") {
     state.mouseX = e.clientX - rect.left;
     state.mouseY = e.clientY - rect.top;
   });
+
+  if (isMobile) {
+    const mobileControls = document.getElementById("mobileControls");
+    if (mobileControls) mobileControls.style.display = "block";
+
+    const handleTouch = (e) => {
+      const rect = canvas.getBoundingClientRect();
+      const t = e.touches[0];
+      if (t) {
+        state.mouseX = t.clientX - rect.left;
+        state.mouseY = t.clientY - rect.top;
+      }
+    };
+    const pad = document.getElementById("shootPad");
+    if (pad) {
+      pad.addEventListener("touchstart", handleTouch);
+      pad.addEventListener("touchmove", handleTouch);
+    }
+
+    const qBtn = document.getElementById("btnQ");
+    const wBtn = document.getElementById("btnW");
+    const eBtn = document.getElementById("btnE");
+    if (qBtn) qBtn.addEventListener("touchstart", (ev) => { ev.preventDefault(); castQ(); });
+    if (wBtn) wBtn.addEventListener("touchstart", (ev) => { ev.preventDefault(); castW(); });
+    if (eBtn) eBtn.addEventListener("touchstart", (ev) => { ev.preventDefault(); castE(); });
+  }
 
   document.addEventListener("keydown", (e) => {
     const k = e.key.toLowerCase();

--- a/style.css
+++ b/style.css
@@ -102,3 +102,43 @@
       display: none;
       text-align: center;
     }
+
+    /* mobile controls */
+    #mobileControls {
+      display: none;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+    }
+    #shootPad {
+      position: absolute;
+      bottom: 10%;
+      left: 5%;
+      width: 30%;
+      height: 30%;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 50%;
+      pointer-events: auto;
+      touch-action: none;
+    }
+    #skillButtons {
+      position: absolute;
+      bottom: 10%;
+      right: 5%;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      pointer-events: auto;
+    }
+    #skillButtons button {
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.6);
+      border: 1px solid #555;
+      color: #fff;
+      font-size: 20px;
+    }


### PR DESCRIPTION
## Summary
- create mobile-specific buttons to cast skills and aim
- style buttons for a basic mobile layout
- detect touch devices in script and wire touch events

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b261280ec8333a7c116b4fa21353e