### PR TITLE
Lock skills and adjust barrier

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
 <body>
   <div id="xpBarContainer"><div id="xpBar"></div></div>
   <div id="abilityBar">
-    <div class="ability"><span class="key">Q</span><span id="qUpgrades">-</span><span class="cd" id="qCd"></span></div>
-    <div class="ability"><span class="key">W</span><span id="wUpgrades">-</span><span class="cd" id="wCd"></span></div>
-    <div class="ability"><span class="key">E</span><span id="eUpgrades">-</span><span class="cd" id="eCd"></span></div>
+    <div id="qAbility" class="ability locked"><span class="key">Q</span><span id="qUpgrades">-</span><span class="cd" id="qCd"></span></div>
+    <div id="wAbility" class="ability locked"><span class="key">W</span><span id="wUpgrades">-</span><span class="cd" id="wCd"></span></div>
+    <div id="eAbility" class="ability locked"><span class="key">E</span><span id="eUpgrades">-</span><span class="cd" id="eCd"></span></div>
   </div>
   <div id="hud">
     <p><strong>Level:</strong> <span id="level">1</span></p>

--- a/style.css
+++ b/style.css
@@ -70,6 +70,9 @@
       border-radius: 4px;
       font-size: 12px;
     }
+    .ability.locked {
+      opacity: 0.3;
+    }
     .ability .key {
       font-weight: bold;
       margin-right: 4px;


### PR DESCRIPTION
## Summary
- start with Q, W, and E locked
- unlock each skill on the first three level ups
- keep UI updated with lock status
- make W barrier grow upward from the ground

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f9921848333a38e8663794edf98