### PR TITLE
Add movable turret crosshair

### DIFF
--- a/__tests__/levelUp.test.js
+++ b/__tests__/levelUp.test.js
@@ -7,6 +7,7 @@ beforeEach(() => {
   global.window = dom.window;
   global.document = dom.window.document;
   global.Image = dom.window.Image;
+  global.Audio = function () { return {}; };
   global.GAME_CONSTANTS = constants.GAME_CONSTANTS;
   global.UPGRADE_FAST_SHOT = constants.UPGRADE_FAST_SHOT;
   global.UPGRADE_BASE_DAMAGE = constants.UPGRADE_BASE_DAMAGE;


### PR DESCRIPTION
## Summary
- add crosshair object to game state
- spawn crosshair when placing the turret
- draw and drag the crosshair using mouse or touch
- make turret bullets aim at crosshair
- fix tests by mocking Audio

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b336a8230833384585586eb50beac