### PR TITLE
Implement achievements and pause fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@
     <h1>Mage Roguelike</h1>
     <p>Controles: Q, W, E para magias. Pressione P para pausar/continuar.</p>
     <button id="resumeBtn">Iniciar</button>
+    <button id="achievementsBtn">Conquistas</button>
+  </div>
+  <div id="achievementsOverlay" class="menu">
+    <h2>Conquistas</h2>
+    <div id="achievementsList"></div>
+    <button id="achievementsCloseBtn">Fechar</button>
   </div>
   <div id="generalUpgradePrompt"></div>
   <canvas id="gameCanvas" width="960" height="540"></canvas>

--- a/style.css
+++ b/style.css
@@ -106,6 +106,11 @@
       text-align: center;
     }
 
+#achievementsList {
+  margin: 10px 0;
+  text-align: left;
+}
+
     /* mobile controls */
     #mobileControls {
       display: none;


### PR DESCRIPTION
## Summary
- pause timer and animations when game is paused
- add Conquistas button and overlay
- track enemy kills and store in localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3fbcbc188333ab25e0c8570313ab