### PR TITLE
Add spider enemy

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -31,12 +31,14 @@ const GAME_CONSTANTS = {
     tanker: { hp: 6, speed: 1, size: 90 },
     voador: { hp: 1, speed: 2.5, size: 50 },
     troll: { hp: 30, speed: 0.7, size: 240 },
+    spider: { hp: 2, speed: 1.2, size: 50 },
   },
   ENEMY_SPAWN_WEIGHTS: {
     miniom: 65,
     tanker: 20,
     voador: 10,
     troll: 5,
+    spider: 10,
   },
 };
 

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -29,6 +29,7 @@ function drawGame() {
     if (e.type === "tanker") img = orcFrames[state.orcFrame];
     else if (e.type === "voador") img = batImg;
     else if (e.type === "troll") img = trollImg;
+    else if (e.type === "spider") img = e.descending ? spiderDownImg : spiderSoloImg;
     else img = goblinFrames[state.goblinFrame];
     if (img.complete) {
       ctx.drawImage(img, e.x, e.y, e.size, e.size);
@@ -36,6 +37,7 @@ function drawGame() {
       if (e.type === "tanker") ctx.fillStyle = "brown";
       else if (e.type === "voador") ctx.fillStyle = "yellow";
       else if (e.type === "troll") ctx.fillStyle = "darkgreen";
+      else if (e.type === "spider") ctx.fillStyle = "purple";
       else ctx.fillStyle = "green";
       ctx.fillRect(e.x, e.y, e.size, e.size);
     }

--- a/js/script.js
+++ b/js/script.js
@@ -60,6 +60,8 @@ let magiaImg = new Image();
 let trollImg = new Image();
 let troncoImg = new Image();
 let crosshairImg = new Image();
+let spiderDownImg = new Image();
+let spiderSoloImg = new Image();
 
 function loadImage(src) {
   return new Promise((resolve, reject) => {
@@ -80,15 +82,25 @@ function loadAudio(src) {
 }
 
 async function loadAssets() {
-  [mageImg, batImg, magiaImg, trollImg, troncoImg, crosshairImg] =
-    await Promise.all([
-      loadImage("../images/mage.png"),
-      loadImage("../images/bat.png"),
-      loadImage("../images/magia.png"),
-      loadImage("../images/troll.png"),
-      loadImage("../images/tronco.png"),
-      loadImage("../images/reticule.png"),
-    ]);
+  [
+    mageImg,
+    batImg,
+    magiaImg,
+    trollImg,
+    troncoImg,
+    crosshairImg,
+    spiderDownImg,
+    spiderSoloImg,
+  ] = await Promise.all([
+    loadImage("../images/mage.png"),
+    loadImage("../images/bat.png"),
+    loadImage("../images/magia.png"),
+    loadImage("../images/troll.png"),
+    loadImage("../images/tronco.png"),
+    loadImage("../images/reticule.png"),
+    loadImage("../images/spider-down.png"),
+    loadImage("../images/spider-solo.png"),
+  ]);
   goblinFrames = await Promise.all([
     loadImage("../images/goblin-1.png"),
     loadImage("../images/goblin-2.png"),
@@ -106,7 +118,7 @@ function loadKillCounts() {
     const data = localStorage.getItem("killCounts");
     if (data) return JSON.parse(data);
   } catch (e) {}
-  return { miniom: 0, tanker: 0, voador: 0, troll: 0 };
+  return { miniom: 0, tanker: 0, voador: 0, troll: 0, spider: 0 };
 }
 
 function saveKillCounts() {
@@ -440,6 +452,7 @@ function showAchievements() {
     <p>Tanker: ${state.killCounts.tanker}</p>
     <p>Voador: ${state.killCounts.voador}</p>
     <p>Troll: ${state.killCounts.troll}</p>
+    <p>Aranha: ${state.killCounts.spider}</p>
   `;
   document.getElementById("achievementsOverlay").style.display = "block";
 }
@@ -624,6 +637,13 @@ function updateGame() {
       e.angle += 0.1;
       e.y = e.baseY + Math.sin(e.angle) * e.amplitude;
     }
+    if (e.type === "spider" && e.descending) {
+      e.y += e.speed;
+      if (e.y >= e.groundY) {
+        e.y = e.groundY;
+        e.descending = false;
+      }
+    }
 
     let spd = e.slow > 0 ? e.speed * e.slowFactor : e.speed;
     if (e.type === "tanker") {
@@ -640,6 +660,7 @@ function updateGame() {
         }
       }
     }
+    if (e.type === "spider" && e.descending) spd = 0;
     e.x -= spd;
     if (e.hp > 0) {
       if (e.x <= -e.size) {

--- a/js/spawner.js
+++ b/js/spawner.js
@@ -7,6 +7,7 @@ function spawnEnemy(state, canvas, GAME_CONSTANTS, forcedType) {
       ["tanker", weights.tanker, 3600],
       ["voador", weights.voador, 7200],
       ["troll", weights.troll, 14400],
+      ["spider", weights.spider, 14400],
     ].filter(([t, _w, frame]) => state.timeFrames >= frame);
     const totalWeight = entries.reduce((sum, [, w]) => sum + w, 0);
     let r = Math.random() * totalWeight;
@@ -28,10 +29,15 @@ function spawnEnemy(state, canvas, GAME_CONSTANTS, forcedType) {
   const stats = baseStats[type];
   const groundY = canvas.height - stats.size - 30;
   const enemy = {
-    x: canvas.width + 20 + Math.random() * 40,
+    x:
+      type === "spider"
+        ? Math.random() * (canvas.width - 200) + 160
+        : canvas.width + 20 + Math.random() * 40,
     y:
       type === "voador"
         ? canvas.height / 2 + (Math.random() * 120 - 60)
+        : type === "spider"
+        ? -stats.size
         : groundY,
     speed: stats.speed * speedMult,
     hp: Math.floor(stats.hp * hpMult),
@@ -45,6 +51,8 @@ function spawnEnemy(state, canvas, GAME_CONSTANTS, forcedType) {
     flash: 0,
     type,
     flying: type === "voador",
+    descending: type === "spider",
+    groundY,
   };
   if (type === "voador") {
     enemy.baseY = enemy.y;
@@ -65,6 +73,12 @@ function spawnEnemy(state, canvas, GAME_CONSTANTS, forcedType) {
       GAME_CONSTANTS.TANKER_DASH_COOLDOWN_MIN;
     enemy.dashDuration = GAME_CONSTANTS.TANKER_DASH_DURATION;
     enemy.dashTime = 0;
+  }
+  if (type === "spider") {
+    const extra = Math.floor(
+      Math.max(0, state.timeFrames - 5 * 60 * 60) / 3600
+    );
+    enemy.speed += extra * 0.2;
   }
   state.enemies.push(enemy);
 }


### PR DESCRIPTION
## Summary
- add spider base stats and spawn weights
- load spider images
- track spider kill counts in achievements
- draw spider using appropriate image while descending or walking
- spawn spider after 4 minutes from above the battlefield
- spiders accelerate every minute after 5 minutes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c31c5fdf48333aada7076e56c93ef