### PR TITLE
Implement local scoreboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -111,6 +111,11 @@
   text-align: left;
 }
 
+#scoreboardList {
+  margin: 10px 0;
+  text-align: left;
+}
+
     /* mobile controls */
     #mobileControls {
       display: none;

--- a/index.html
+++ b/index.html
@@ -34,15 +34,23 @@
     <p>Controles: Q, W, E para magias. Pressione P para pausar/continuar.</p>
     <button id="resumeBtn">Iniciar</button>
     <button id="achievementsBtn">Conquistas</button>
+    <button id="scoreboardBtn">Recordes</button>
   </div>
   <div id="achievementsOverlay" class="menu">
     <h2>Conquistas</h2>
     <div id="achievementsList"></div>
+    <p><strong>Melhor Tempo:</strong> <span id="bestTimeAchievement">0:00</span></p>
     <button id="achievementsCloseBtn">Fechar</button>
+  </div>
+  <div id="scoreboardOverlay" class="menu">
+    <h2>Recordes</h2>
+    <ol id="scoreboardList"></ol>
+    <button id="scoreboardCloseBtn">Fechar</button>
   </div>
   <div id="gameOverOverlay" class="menu">
     <h1>Game Over</h1>
     <p>Seu tempo: <span id="finalTime"></span></p>
+    <p>Recorde: <span id="bestTime">0:00</span></p>
     <button id="restartBtn">Novo Jogo</button>
   </div>
   <div id="generalUpgradePrompt"></div>


### PR DESCRIPTION
## Summary
- add scoreboard button, overlay and best time lines
- style scoreboard list
- store high scores in localStorage
- display record times on achievements and game over screens
- update scoreboard on new game, load and when overlay is shown

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7c0b8d988333ac87d4e4988dad91