### PR TITLE
Update HUD and troll spawn timing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,10 +65,11 @@
       pointer-events: none;
     }
     .ability {
-      background: rgba(0,0,0,0.6);
-      padding: 4px 8px;
-      border-radius: 4px;
-      font-size: 12px;
+      background: rgba(0,0,0,0.8);
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 16px;
+      border: 2px solid #fff;
     }
     .ability.locked {
       opacity: 0.3;
@@ -76,10 +77,12 @@
     .ability .key {
       font-weight: bold;
       margin-right: 4px;
+      font-size: 18px;
     }
     .ability .cd {
       margin-left: 4px;
       color: #ffb;
+      font-size: 14px;
     }
 
     .overlay {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <p><strong>Time:</strong> <span id="timer">0:00</span></p>
     <p><strong>Combo:</strong> <span id="comboName">None</span></p>
     <p><strong>Vidas:</strong> <span id="lives">4</span></p>
+    <p><strong>Barreira:</strong> <span id="barrierHp">0</span></p>
   </div>
   <div id="upgradePrompt">
     <p>Escolha onde aplicar o poder: <span id="upgradeElement"></span></p>

--- a/js/script.js
+++ b/js/script.js
@@ -17,6 +17,7 @@ const hudEls = {
   timer: document.getElementById("timer"),
   comboName: document.getElementById("comboName"),
   lives: document.getElementById("lives"),
+  barrierHp: document.getElementById("barrierHp"),
   abilities: {
     Q: document.getElementById("qAbility"),
     W: document.getElementById("wAbility"),
@@ -37,6 +38,7 @@ const hudCache = {
   timer: null,
   comboName: null,
   lives: null,
+  barrierHp: null,
   skillsUnlocked: { Q: null, W: null, E: null },
 };
 const isMobile =
@@ -592,6 +594,11 @@ function updateHUD() {
   if (hudEls.lives && hudCache.lives !== state.lives) {
     hudEls.lives.textContent = state.lives;
     hudCache.lives = state.lives;
+  }
+  const bHp = state.barriers.length > 0 ? Math.ceil(state.barriers[0].hp) : 0;
+  if (hudEls.barrierHp && hudCache.barrierHp !== bHp) {
+    hudEls.barrierHp.textContent = bHp;
+    hudCache.barrierHp = bHp;
   }
 }
 

--- a/js/spawner.js
+++ b/js/spawner.js
@@ -6,7 +6,7 @@ function spawnEnemy(state, canvas, GAME_CONSTANTS, forcedType) {
       ["miniom", weights.miniom, 0],
       ["tanker", weights.tanker, 3600],
       ["voador", weights.voador, 7200],
-      ["troll", weights.troll, 14400],
+      ["troll", weights.troll, 18000],
       ["spider", weights.spider, 14400],
     ].filter(([t, _w, frame]) => state.timeFrames >= frame);
     const totalWeight = entries.reduce((sum, [, w]) => sum + w, 0);


### PR DESCRIPTION
## Summary
- delay troll spawn to 5 minutes
- show barrier hit points on the HUD
- enlarge ability HUD elements for better visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c815254908333ac9f266f8c027db0