### PR TITLE
Change turret bomb color

### DIFF
--- a/js/renderer.js
+++ b/js/renderer.js
@@ -58,8 +58,9 @@ function drawGame() {
   });
 
   state.bullets.forEach((b) => {
-    if (magiaImg.complete) {
-      ctx.drawImage(magiaImg, b.x - 10, b.y - 10, 20, 20);
+    const img = b.image === undefined ? magiaImg : b.image;
+    if (img && img.complete) {
+      ctx.drawImage(img, b.x - 10, b.y - 10, 20, 20);
     } else {
       ctx.fillStyle = b.color || "white";
       ctx.beginPath();

--- a/js/script.js
+++ b/js/script.js
@@ -311,6 +311,7 @@ function castE() {
         dmg: t.dmg,
         elements: [],
         color: "red",
+        image: null,
         aoe: 80,
       });
       state.turretSpecialCd = GAME_CONSTANTS.TURRET_SPECIAL_COOLDOWN;


### PR DESCRIPTION
## Summary
- highlight the turret special projectile with a red circle
- renderer now respects bullet-specific images

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8cd0a208833399dd1b12fa0a0498