### PR TITLE
Implement bomb cooldown HUD and upgrades

### DIFF
--- a/__tests__/levelUp.test.js
+++ b/__tests__/levelUp.test.js
@@ -18,6 +18,8 @@ beforeEach(() => {
   global.UPGRADE_TURRET_FASTER = constants.UPGRADE_TURRET_FASTER;
   global.UPGRADE_BARRIER_HEIGHT = constants.UPGRADE_BARRIER_HEIGHT;
   global.UPGRADE_BULLET_AOE = constants.UPGRADE_BULLET_AOE;
+  global.UPGRADE_E_BOMB_DAMAGE = constants.UPGRADE_E_BOMB_DAMAGE;
+  global.UPGRADE_E_BOMB_AOE = constants.UPGRADE_E_BOMB_AOE;
   const canvas = document.getElementById('gameCanvas');
   canvas.getContext = () => ({ clearRect() {}, fillRect() {}, beginPath() {}, arc() {}, fill() {}, drawImage() {}, stroke() {}, lineTo() {}, moveTo() {} });
 });

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <div id="abilityBar">
     <div id="qAbility" class="ability locked"><span class="key">Q</span><span id="qUpgrades">-</span><span class="cd" id="qCd"></span></div>
     <div id="wAbility" class="ability locked"><span class="key">W</span><span id="wUpgrades">-</span><span class="cd" id="wCd"></span></div>
-    <div id="eAbility" class="ability locked"><span class="key">E</span><span id="eUpgrades">-</span><span class="cd" id="eCd"></span></div>
+    <div id="eAbility" class="ability locked"><span class="key">E</span><span id="eUpgrades">-</span><span class="cd" id="eCd"></span><span class="cd" id="eBombCd"></span></div>
   </div>
   <div id="hud">
     <p><strong>Level:</strong> <span id="level">1</span></p>

--- a/js/constants.js
+++ b/js/constants.js
@@ -101,6 +101,20 @@ const UPGRADE_BULLET_AOE = {
   desc: "Ataque básico em área",
 };
 
+const UPGRADE_E_BOMB_DAMAGE = {
+  type: "stat",
+  prop: "eBombDamageBonus",
+  value: 1,
+  desc: "+ dano bomba E",
+};
+
+const UPGRADE_E_BOMB_AOE = {
+  type: "stat",
+  prop: "eBombAoeBonus",
+  value: 20,
+  desc: "+ área bomba E",
+};
+
 if (typeof module !== "undefined") {
   module.exports = {
     GAME_CONSTANTS,
@@ -112,6 +126,8 @@ if (typeof module !== "undefined") {
     UPGRADE_TURRET_FASTER,
     UPGRADE_BARRIER_HEIGHT,
     UPGRADE_BULLET_AOE,
+    UPGRADE_E_BOMB_DAMAGE,
+    UPGRADE_E_BOMB_AOE,
     // expose novo cooldown especial da torreta
     TURRET_SPECIAL_COOLDOWN: GAME_CONSTANTS.TURRET_SPECIAL_COOLDOWN,
   };

--- a/js/script.js
+++ b/js/script.js
@@ -14,6 +14,7 @@ const hudEls = {
   qCd: document.getElementById("qCd"),
   wCd: document.getElementById("wCd"),
   eCd: document.getElementById("eCd"),
+  eBombCd: document.getElementById("eBombCd"),
   timer: document.getElementById("timer"),
   comboName: document.getElementById("comboName"),
   lives: document.getElementById("lives"),
@@ -35,6 +36,7 @@ const hudCache = {
   qCd: null,
   wCd: null,
   eCd: null,
+  eBombCd: null,
   timer: null,
   comboName: null,
   lives: null,
@@ -159,6 +161,8 @@ const state = {
   qDamageBonus: 0,
   wBonusHp: 0,
   eDamageBonus: 0,
+  eBombDamageBonus: 0,
+  eBombAoeBonus: 0,
   qCooldown: 300,
   turretFireDelay: GAME_CONSTANTS.TURRET_FIRE_COOLDOWN,
   turretSpecialCd: 0,
@@ -309,11 +313,11 @@ function castE() {
         y: t.y,
         dx: Math.cos(ang) * spd,
         dy: Math.sin(ang) * spd,
-        dmg: t.dmg,
+        dmg: t.dmg + state.eBombDamageBonus,
         elements: [],
         color: "red",
         image: null,
-        aoe: 80,
+        aoe: 80 + state.eBombAoeBonus,
       });
       state.turretSpecialCd = GAME_CONSTANTS.TURRET_SPECIAL_COOLDOWN;
     }
@@ -369,6 +373,8 @@ const generalUpgradesPool = [
   UPGRADE_TURRET_FASTER,
   UPGRADE_BARRIER_HEIGHT,
   UPGRADE_BULLET_AOE,
+  UPGRADE_E_BOMB_DAMAGE,
+  UPGRADE_E_BOMB_AOE,
 ];
 
 if (typeof module !== "undefined") {
@@ -472,6 +478,8 @@ function resetState() {
     qDamageBonus: 0,
     wBonusHp: 0,
     eDamageBonus: 0,
+    eBombDamageBonus: 0,
+    eBombAoeBonus: 0,
     qCooldown: 300,
     turretFireDelay: GAME_CONSTANTS.TURRET_FIRE_COOLDOWN,
     turretSpecialCd: 0,
@@ -590,6 +598,12 @@ function updateHUD() {
   if (hudEls.eCd && hudCache.eCd !== eCdText) {
     hudEls.eCd.textContent = eCdText;
     hudCache.eCd = eCdText;
+  }
+  const bombCdText =
+    state.turretSpecialCd > 0 ? Math.ceil(state.turretSpecialCd / 60) : "";
+  if (hudEls.eBombCd && hudCache.eBombCd !== bombCdText) {
+    hudEls.eBombCd.textContent = bombCdText;
+    hudCache.eBombCd = bombCdText;
   }
 
   ["Q", "W", "E"].forEach((k) => {

--- a/js/upgrades.js
+++ b/js/upgrades.js
@@ -9,12 +9,14 @@ function levelUp() {
     return;
   }
 
+  const available = generalUpgradesPool.filter((u) => {
+    if (u.prop === "eBombDamageBonus") return state.eBombDamageBonus < 5;
+    if (u.prop === "eBombAoeBonus") return state.eBombAoeBonus < 5;
+    return true;
+  });
   const opts = [];
-  while (opts.length < 3) {
-    const rand =
-      generalUpgradesPool[
-        Math.floor(Math.random() * generalUpgradesPool.length)
-      ];
+  while (opts.length < Math.min(3, available.length)) {
+    const rand = available[Math.floor(Math.random() * available.length)];
     if (!opts.includes(rand)) opts.push(rand);
   }
   state.upgradeOptions = opts;
@@ -92,6 +94,10 @@ function applyStatUpgrade(up) {
     state.barrierHeight += up.value;
   } else if (up.prop === "bulletAOE") {
     state.bulletAOE += up.value;
+  } else if (up.prop === "eBombDamageBonus") {
+    state.eBombDamageBonus += up.value;
+  } else if (up.prop === "eBombAoeBonus") {
+    state.eBombAoeBonus += up.value;
   }
   state.generalUpgrades.push(up.desc);
 }


### PR DESCRIPTION
## Summary
- show bomb cooldown on HUD
- increase E bomb damage and area with upgrades
- limit bomb upgrades to 5
- include new upgrade constants and test initialization

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c908e36848333b10917e49ca06c2e